### PR TITLE
feat: Create group

### DIFF
--- a/src/components/features/CreateGroup.tsx
+++ b/src/components/features/CreateGroup.tsx
@@ -1,0 +1,94 @@
+import { useForm } from 'react-hook-form'
+import { useEffect, useState } from 'react'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from '@/components/ui/form'
+import { PlusIcon } from 'lucide-react'
+
+const CreateGroupSchema = z.object({
+  name: z.string().min(3, { message: 'Name must be at least 3 characters.' })
+})
+
+type CreateGroupData = z.infer<typeof CreateGroupSchema>
+
+type CreateGroupProps = {
+  onCreate: (data: CreateGroupData) => void
+}
+export function CreateGroup({ onCreate }: CreateGroupProps) {
+  // Managing the dialog open state
+  const [open, setOpen] = useState(false)
+
+  const form = useForm<CreateGroupData>({
+    resolver: zodResolver(CreateGroupSchema),
+    defaultValues: { name: '' }
+  })
+
+  // Reset form when dialog is closed
+  useEffect(() => {
+    if (!open) form.reset()
+  }, [open])
+
+  const onSubmit = (data: CreateGroupData) => {
+    onCreate(data)
+    setOpen(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button className='w-full mt-2'>
+          <PlusIcon />
+          Create Group
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-md">
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)}>
+            <DialogHeader>
+              <DialogTitle>Create Group</DialogTitle>
+              <DialogDescription>
+                Create a new group to organize projects.
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="space-y-4 my-6">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Name</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Group name" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button variant="outline">Cancel</Button>
+              </DialogClose>
+              <Button type="submit">Create</Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
This pull request adds a new `CreateGroup` component for creating groups and integrates it into the `CreateProject` workflow. The main improvements are around user experience: users can now create a new group directly from the project creation dialog, and the group selection updates immediately.

**New group creation and selection flow:**

* Added a new `CreateGroup` component (`src/components/features/CreateGroup.tsx`) that provides a dialog-based form for creating groups, including validation and form reset logic.
* Integrated the `CreateGroup` component into the group selection dropdown in `CreateProject`, allowing users to create a group if none exist or if they want a new one. [[1]](diffhunk://#diff-de0e44bca9f4ad1e23515cfa2437f2f5c8f3f5b47f6694e49e99740af9edf779R8) [[2]](diffhunk://#diff-de0e44bca9f4ad1e23515cfa2437f2f5c8f3f5b47f6694e49e99740af9edf779R163-R165)
* Reworked group state management in `CreateProject` to use local state (`groups`) that updates when a new group is created, instead of relying solely on the Redux selector.
* Implemented `handleCreateGroup` in `CreateProject` to add the new group to local state, update the form value, and show a toast notification.

**UI/UX improvements:**

* Updated the group selection dropdown to control its open state and close automatically when a new group is created, improving the user experience.